### PR TITLE
Add support for different color models in future

### DIFF
--- a/colors.go
+++ b/colors.go
@@ -6,13 +6,37 @@ import (
 	"strings"
 )
 
-// CSSColModLevel4 is the Model for CSS Color Module Level 4.
-var CSSColModLevel4 color.Model = color.ModelFunc(func(c color.Color) color.Color {
+// Model can convert any Color to one from its own color model, and can convert
+// a color to the name of the color, and can convert from a name of a color to
+// the color.
+type Model interface {
+	color.Model
+	ColorToName(c color.Color) string
+	NameToColor(name string) (c color.Color, ok bool)
+}
+
+// CSSColModLvl4 is the Model for CSS Color Module Level 4.
+// https://www.w3.org/TR/css-color-4/#named-colors
+var CSSColModLvl4 Model = cssColModLvl4{}
+
+type cssColModLvl4 struct{}
+
+func (mod cssColModLvl4) Convert(c color.Color) color.Color {
 	nc, _ := nearestColor(c)
 	return nc
-})
+}
 
-var colors = map[string]color.RGBA{
+func (mod cssColModLvl4) ColorToName(c color.Color) string {
+	_, n := nearestColor(c)
+	return n
+}
+
+func (mod cssColModLvl4) NameToColor(name string) (c color.Color, ok bool) {
+	c, ok = cssColModLvl4Colors[name]
+	return
+}
+
+var cssColModLvl4Colors = map[string]color.RGBA{
 	"":                     {}, // transparent
 	"aliceblue":            {240, 248, 255, 255},
 	"antiquewhite":         {250, 235, 215, 255},
@@ -166,7 +190,7 @@ var colors = map[string]color.RGBA{
 
 func nearestColor(c color.Color) (nc color.Color, name string) {
 	var mind uint32 = math.MaxUint32
-	for n, cc := range colors {
+	for n, cc := range cssColModLvl4Colors {
 		d := colorDissimilarity(c, cc)
 		if d < mind || d == mind && strings.Compare(n, name) < 0 {
 			mind = d

--- a/consts.go
+++ b/consts.go
@@ -4,5 +4,5 @@ const (
 	// Extension is the extension for Extension image files.
 	Extension = ".bi"
 	// MagicNumber is the magic number at the start of BI files.
-	MagicNumber = "bi,cssColModLvl4\n"
+	MagicNumber = "bi"
 )

--- a/consts.go
+++ b/consts.go
@@ -1,8 +1,8 @@
 package bi
 
 const (
-	// BI is the extension for BI image files.
-	BI = ".bi"
-	// Magic is the magic number at the start of BI files.
-	Magic = "bi\n"
+	// Extension is the extension for Extension image files.
+	Extension = ".bi"
+	// MagicNumber is the magic number at the start of BI files.
+	MagicNumber = "bi,cssColModLvl4\n"
 )

--- a/reader.go
+++ b/reader.go
@@ -48,12 +48,12 @@ func decode(r io.Reader) (m image.Image, err error) {
 			return
 		}
 		for x, n := range row {
-			c, ok := colors[n]
+			c, ok := CSSColModLvl4.NameToColor(n)
 			if !ok {
 				err = fmt.Errorf("bi: unexpected colour %q on line %d", n, y+2)
 				return
 			}
-			img.SetRGBA(x, y, c)
+			img.Set(x, y, c)
 		}
 	}
 	m = img
@@ -67,7 +67,7 @@ func decodeConfig(r io.Reader) (cfg image.Config, err error) {
 	}
 	cfg.Width = len(cs[0])
 	cfg.Height = len(cs)
-	cfg.ColorModel = CSSColModLevel4
+	cfg.ColorModel = CSSColModLvl4
 	return
 }
 

--- a/writer.go
+++ b/writer.go
@@ -16,7 +16,7 @@ func Encode(w io.Writer, m image.Image) error {
 	mx, my := mp.X, mp.Y
 	for y := 0; y < my; y++ {
 		for x := 0; x < mx; x++ {
-			_, n := nearestColor(m.At(x, y))
+			n := CSSColModLvl4.ColorToName(m.At(x, y))
 			if _, err := fmt.Fprint(w, n); err != nil {
 				return err
 			}


### PR DESCRIPTION
This PR makes it relatively easy to add color models other than [CSS Color Module Level 4](https://www.w3.org/TR/css-color-4/#named-colors) to bi as discussed in #1.

It does this by adding a new interface, `Model`, that allows a generic color model to be used in the encode and decode stages.

Color models will be specified in the bi header (the first line of `.bi` files) after the `bi` magic number. The idea is that you can specify the color model of the bi file in the header. So `bi,cssColModLvl4` is the default header for a bi file now. This is a breaking change.