### PR TITLE
Add support for third-party color models

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -56,12 +56,11 @@ func decodeHeader(r *bufio.Reader) (mod Model, err error) {
 		err = fmt.Errorf("bi: invalid header, too many tokens")
 		return
 	}
-	switch tkns[1] {
-	case "cssColModLvl4":
-		mod = CSSColModLvl4
-	default:
+	val, ok := models.Load(tkns[1])
+	if !ok {
 		err = fmt.Errorf("bi: color model %q is invalid", tkns[1])
 	}
+	mod, _ = val.(Model)
 	return
 }
 

--- a/writer.go
+++ b/writer.go
@@ -6,17 +6,18 @@ import (
 	"io"
 )
 
-// Encode encodes the Image m to the Writer w in BI format. As BI only supports
-// 148 colors, this process is very lossy.
-func Encode(w io.Writer, m image.Image) error {
-	if _, err := w.Write([]byte("bi\n")); err != nil {
+// Encode encodes the Image m to the Writer w in BI format using the Model mod.
+// This is usually a very lossy process.
+func Encode(w io.Writer, m image.Image, mod Model) error {
+	hdr := MagicNumber + "," + mod.Name() + "\n"
+	if _, err := w.Write([]byte(hdr)); err != nil {
 		return err
 	}
 	mp := m.Bounds().Max
 	mx, my := mp.X, mp.Y
 	for y := 0; y < my; y++ {
 		for x := 0; x < mx; x++ {
-			n := CSSColModLvl4.ColorToName(m.At(x, y))
+			n := mod.ColorToName(m.At(x, y))
 			if _, err := fmt.Fprint(w, n); err != nil {
 				return err
 			}


### PR DESCRIPTION
This PR adds the ability to register third-party color models and adds a hex color model to bi. So the header would look like `bi,hex` for that.