### PR TITLE
Cleanup color model interface and names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Bad Image (`.bi`)
 
 `bi` is a library for the BI image format.
-The BI format encodes images so that they are essentially CSV files using the named colors in the [CSS Color Module Level 4](https://www.w3.org/TR/css-color-4/#named-colors) or hex quadruplets to create a 2d matrix of color names.
+The BI format encodes images so that they are essentially 2D matrices of plaintext color names such as those found in the [CSS Color Module Level 4](https://www.w3.org/TR/css-color-4/#named-colors) or hex quadruplets like `#FF69B4FF`.
 There is also support for third party color models.
-This means that they are plaintext editable.
 Nice.
 
 For example, a valid 2x2 pixel image is:
+
 ```
-bi,cssColModLvl4
+bi,v1
 red,green
 blue,white
 ```
@@ -25,7 +25,7 @@ Before BI encoding.
 
 ![After BI encoding using the CSS Color Module Level 4 color model. And re-encoded as PNG obvs.](./misc/lenna2.png)
 
-*After BI encoding using the CSS Color Module Level 4 color model. And re-encoded as PNG obvs.*
+After BI encoding using the CSS Color Module Level 4 color model. And re-encoded as PNG obvs.
 
 ---
 

--- a/models.go
+++ b/models.go
@@ -12,7 +12,7 @@ import (
 // a color to the name of the color, and can convert from a name of a color to
 // the color.
 type Model interface {
-	Name() string
+	ID() string
 	color.Model
 	ColorToName(c color.Color) string
 	NameToColor(name string) (c color.Color, ok bool)
@@ -22,196 +22,190 @@ var models sync.Map
 
 // RegisterColorModel registers a Model for use by Decode.
 func RegisterColorModel(mod Model) {
-	models.Store(mod.Name(), mod)
+	models.Store(mod.ID(), mod)
 }
 
-// CSSColModLvl4 is a Model for CSS Color Module Level 4.
+// Standard is a Model for CSS Color Module Level 4.
 //
 // https://www.w3.org/TR/css-color-4/#named-colors
-var CSSColModLvl4 Model = cssColModLvl4{}
+var Standard Model = standard{}
 
-// Hex is a Model for hex quadruplet color codes in the format #00000000,
-// including alpha.
-//
-// https://css-tricks.com/8-digit-hex-codes/
-var Hex Model = hex{}
+type standard struct{}
 
-type cssColModLvl4 struct{}
-
-func (mod cssColModLvl4) Name() string {
-	return "cssColModLvl4"
+func (mod standard) ID() string {
+	return "v1"
 }
 
-func (mod cssColModLvl4) Convert(c color.Color) color.Color {
-	nc, _ := nearestColor(c)
+func (mod standard) Convert(c color.Color) color.Color {
+	nc, _ := nearestColor(c, standardColors)
 	return nc
 }
 
-func (mod cssColModLvl4) ColorToName(c color.Color) string {
-	_, n := nearestColor(c)
+func (mod standard) ColorToName(c color.Color) string {
+	_, n := nearestColor(c, standardColors)
 	return n
 }
 
-func (mod cssColModLvl4) NameToColor(name string) (c color.Color, ok bool) {
-	c, ok = cssColModLvl4Colors[name]
+func (mod standard) NameToColor(name string) (c color.Color, ok bool) {
+	c, ok = standardColors[name]
 	return
 }
 
-var cssColModLvl4Colors = map[string]color.RGBA{
-	"":                     {}, // transparent
-	"aliceblue":            {240, 248, 255, 255},
-	"antiquewhite":         {250, 235, 215, 255},
-	"aqua":                 {0, 255, 255, 255},
-	"aquamarine":           {127, 255, 212, 255},
-	"azure":                {240, 255, 255, 255},
-	"beige":                {245, 245, 220, 255},
-	"bisque":               {255, 228, 196, 255},
-	"black":                {0, 0, 0, 255},
-	"blanchedalmond":       {255, 235, 205, 255},
-	"blue":                 {0, 0, 255, 255},
-	"blueviolet":           {138, 43, 226, 255},
-	"brown":                {165, 42, 42, 255},
-	"burlywood":            {222, 184, 135, 255},
-	"cadetblue":            {95, 158, 160, 255},
-	"chartreuse":           {127, 255, 0, 255},
-	"chocolate":            {210, 105, 30, 255},
-	"coral":                {255, 127, 80, 255},
-	"cornflowerblue":       {100, 149, 237, 255},
-	"cornsilk":             {255, 248, 220, 255},
-	"crimson":              {220, 20, 60, 255},
-	"cyan":                 {0, 255, 255, 255},
-	"darkblue":             {0, 0, 139, 255},
-	"darkcyan":             {0, 139, 139, 255},
-	"darkgoldenrod":        {184, 134, 11, 255},
-	"darkgray":             {169, 169, 169, 255},
-	"darkgreen":            {0, 100, 0, 255},
-	"darkgrey":             {169, 169, 169, 255},
-	"darkkhaki":            {189, 183, 107, 255},
-	"darkmagenta":          {139, 0, 139, 255},
-	"darkolivegreen":       {85, 107, 47, 255},
-	"darkorange":           {255, 140, 0, 255},
-	"darkorchid":           {153, 50, 204, 255},
-	"darkred":              {139, 0, 0, 255},
-	"darksalmon":           {233, 150, 122, 255},
-	"darkseagreen":         {143, 188, 143, 255},
-	"darkslateblue":        {72, 61, 139, 255},
-	"darkslategray":        {47, 79, 79, 255},
-	"darkslategrey":        {47, 79, 79, 255},
-	"darkturquoise":        {0, 206, 209, 255},
-	"darkviolet":           {148, 0, 211, 255},
-	"deeppink":             {255, 20, 147, 255},
-	"deepskyblue":          {0, 191, 255, 255},
-	"dimgray":              {105, 105, 105, 255},
-	"dimgrey":              {105, 105, 105, 255},
-	"dodgerblue":           {30, 144, 255, 255},
-	"firebrick":            {178, 34, 34, 255},
-	"floralwhite":          {255, 250, 240, 255},
-	"forestgreen":          {34, 139, 34, 255},
-	"fuchsia":              {255, 0, 255, 255},
-	"gainsboro":            {220, 220, 220, 255},
-	"ghostwhite":           {248, 248, 255, 255},
-	"gold":                 {255, 215, 0, 255},
-	"goldenrod":            {218, 165, 32, 255},
-	"gray":                 {128, 128, 128, 255},
-	"green":                {0, 128, 0, 255},
-	"greenyellow":          {173, 255, 47, 255},
-	"grey":                 {128, 128, 128, 255},
-	"honeydew":             {240, 255, 240, 255},
-	"hotpink":              {255, 105, 180, 255},
-	"indianred":            {205, 92, 92, 255},
-	"indigo":               {75, 0, 130, 255},
-	"ivory":                {255, 255, 240, 255},
-	"khaki":                {240, 230, 140, 255},
-	"lavender":             {230, 230, 250, 255},
-	"lavenderblush":        {255, 240, 245, 255},
-	"lawngreen":            {124, 252, 0, 255},
-	"lemonchiffon":         {255, 250, 205, 255},
-	"lightblue":            {173, 216, 230, 255},
-	"lightcoral":           {240, 128, 128, 255},
-	"lightcyan":            {224, 255, 255, 255},
-	"lightgoldenrodyellow": {250, 250, 210, 255},
-	"lightgray":            {211, 211, 211, 255},
-	"lightgreen":           {144, 238, 144, 255},
-	"lightgrey":            {211, 211, 211, 255},
-	"lightpink":            {255, 182, 193, 255},
-	"lightsalmon":          {255, 160, 122, 255},
-	"lightseagreen":        {32, 178, 170, 255},
-	"lightskyblue":         {135, 206, 250, 255},
-	"lightslategray":       {119, 136, 153, 255},
-	"lightslategrey":       {119, 136, 153, 255},
-	"lightsteelblue":       {176, 196, 222, 255},
-	"lightyellow":          {255, 255, 224, 255},
-	"lime":                 {0, 255, 0, 255},
-	"limegreen":            {50, 205, 50, 255},
-	"linen":                {250, 240, 230, 255},
-	"magenta":              {255, 0, 255, 255},
-	"maroon":               {128, 0, 0, 255},
-	"mediumaquamarine":     {102, 205, 170, 255},
-	"mediumblue":           {0, 0, 205, 255},
-	"mediumorchid":         {186, 85, 211, 255},
-	"mediumpurple":         {147, 112, 219, 255},
-	"mediumseagreen":       {60, 179, 113, 255},
-	"mediumslateblue":      {123, 104, 238, 255},
-	"mediumspringgreen":    {0, 250, 154, 255},
-	"mediumturquoise":      {72, 209, 204, 255},
-	"mediumvioletred":      {199, 21, 133, 255},
-	"midnightblue":         {25, 25, 112, 255},
-	"mintcream":            {245, 255, 250, 255},
-	"mistyrose":            {255, 228, 225, 255},
-	"moccasin":             {255, 228, 181, 255},
-	"navajowhite":          {255, 222, 173, 255},
-	"navy":                 {0, 0, 128, 255},
-	"oldlace":              {253, 245, 230, 255},
-	"olive":                {128, 128, 0, 255},
-	"olivedrab":            {107, 142, 35, 255},
-	"orange":               {255, 165, 0, 255},
-	"orangered":            {255, 69, 0, 255},
-	"orchid":               {218, 112, 214, 255},
-	"palegoldenrod":        {238, 232, 170, 255},
-	"palegreen":            {152, 251, 152, 255},
-	"paleturquoise":        {175, 238, 238, 255},
-	"palevioletred":        {219, 112, 147, 255},
-	"papayawhip":           {255, 239, 213, 255},
-	"peachpuff":            {255, 218, 185, 255},
-	"peru":                 {205, 133, 63, 255},
-	"pink":                 {255, 192, 203, 255},
-	"plum":                 {221, 160, 221, 255},
-	"powderblue":           {176, 224, 230, 255},
-	"purple":               {128, 0, 128, 255},
-	"rebeccapurple":        {102, 51, 153, 255},
-	"red":                  {255, 0, 0, 255},
-	"rosybrown":            {188, 143, 143, 255},
-	"royalblue":            {65, 105, 225, 255},
-	"saddlebrown":          {139, 69, 19, 255},
-	"salmon":               {250, 128, 114, 255},
-	"sandybrown":           {244, 164, 96, 255},
-	"seagreen":             {46, 139, 87, 255},
-	"seashell":             {255, 245, 238, 255},
-	"sienna":               {160, 82, 45, 255},
-	"silver":               {192, 192, 192, 255},
-	"skyblue":              {135, 206, 235, 255},
-	"slateblue":            {106, 90, 205, 255},
-	"slategray":            {112, 128, 144, 255},
-	"slategrey":            {112, 128, 144, 255},
-	"snow":                 {255, 250, 250, 255},
-	"springgreen":          {0, 255, 127, 255},
-	"steelblue":            {70, 130, 180, 255},
-	"tan":                  {210, 180, 140, 255},
-	"teal":                 {0, 128, 128, 255},
-	"thistle":              {216, 191, 216, 255},
-	"tomato":               {255, 99, 71, 255},
-	"turquoise":            {64, 224, 208, 255},
-	"violet":               {238, 130, 238, 255},
-	"wheat":                {245, 222, 179, 255},
-	"white":                {255, 255, 255, 255},
-	"whitesmoke":           {245, 245, 245, 255},
-	"yellow":               {255, 255, 0, 255},
-	"yellowgreen":          {154, 205, 50, 255},
+var standardColors = map[string]color.Color{
+	"":                     color.RGBA{}, // transparent
+	"aliceblue":            color.RGBA{240, 248, 255, 255},
+	"antiquewhite":         color.RGBA{250, 235, 215, 255},
+	"aqua":                 color.RGBA{0, 255, 255, 255},
+	"aquamarine":           color.RGBA{127, 255, 212, 255},
+	"azure":                color.RGBA{240, 255, 255, 255},
+	"beige":                color.RGBA{245, 245, 220, 255},
+	"bisque":               color.RGBA{255, 228, 196, 255},
+	"black":                color.RGBA{0, 0, 0, 255},
+	"blanchedalmond":       color.RGBA{255, 235, 205, 255},
+	"blue":                 color.RGBA{0, 0, 255, 255},
+	"blueviolet":           color.RGBA{138, 43, 226, 255},
+	"brown":                color.RGBA{165, 42, 42, 255},
+	"burlywood":            color.RGBA{222, 184, 135, 255},
+	"cadetblue":            color.RGBA{95, 158, 160, 255},
+	"chartreuse":           color.RGBA{127, 255, 0, 255},
+	"chocolate":            color.RGBA{210, 105, 30, 255},
+	"coral":                color.RGBA{255, 127, 80, 255},
+	"cornflowerblue":       color.RGBA{100, 149, 237, 255},
+	"cornsilk":             color.RGBA{255, 248, 220, 255},
+	"crimson":              color.RGBA{220, 20, 60, 255},
+	"cyan":                 color.RGBA{0, 255, 255, 255},
+	"darkblue":             color.RGBA{0, 0, 139, 255},
+	"darkcyan":             color.RGBA{0, 139, 139, 255},
+	"darkgoldenrod":        color.RGBA{184, 134, 11, 255},
+	"darkgray":             color.RGBA{169, 169, 169, 255},
+	"darkgreen":            color.RGBA{0, 100, 0, 255},
+	"darkgrey":             color.RGBA{169, 169, 169, 255},
+	"darkkhaki":            color.RGBA{189, 183, 107, 255},
+	"darkmagenta":          color.RGBA{139, 0, 139, 255},
+	"darkolivegreen":       color.RGBA{85, 107, 47, 255},
+	"darkorange":           color.RGBA{255, 140, 0, 255},
+	"darkorchid":           color.RGBA{153, 50, 204, 255},
+	"darkred":              color.RGBA{139, 0, 0, 255},
+	"darksalmon":           color.RGBA{233, 150, 122, 255},
+	"darkseagreen":         color.RGBA{143, 188, 143, 255},
+	"darkslateblue":        color.RGBA{72, 61, 139, 255},
+	"darkslategray":        color.RGBA{47, 79, 79, 255},
+	"darkslategrey":        color.RGBA{47, 79, 79, 255},
+	"darkturquoise":        color.RGBA{0, 206, 209, 255},
+	"darkviolet":           color.RGBA{148, 0, 211, 255},
+	"deeppink":             color.RGBA{255, 20, 147, 255},
+	"deepskyblue":          color.RGBA{0, 191, 255, 255},
+	"dimgray":              color.RGBA{105, 105, 105, 255},
+	"dimgrey":              color.RGBA{105, 105, 105, 255},
+	"dodgerblue":           color.RGBA{30, 144, 255, 255},
+	"firebrick":            color.RGBA{178, 34, 34, 255},
+	"floralwhite":          color.RGBA{255, 250, 240, 255},
+	"forestgreen":          color.RGBA{34, 139, 34, 255},
+	"fuchsia":              color.RGBA{255, 0, 255, 255},
+	"gainsboro":            color.RGBA{220, 220, 220, 255},
+	"ghostwhite":           color.RGBA{248, 248, 255, 255},
+	"gold":                 color.RGBA{255, 215, 0, 255},
+	"goldenrod":            color.RGBA{218, 165, 32, 255},
+	"gray":                 color.RGBA{128, 128, 128, 255},
+	"green":                color.RGBA{0, 128, 0, 255},
+	"greenyellow":          color.RGBA{173, 255, 47, 255},
+	"grey":                 color.RGBA{128, 128, 128, 255},
+	"honeydew":             color.RGBA{240, 255, 240, 255},
+	"hotpink":              color.RGBA{255, 105, 180, 255},
+	"indianred":            color.RGBA{205, 92, 92, 255},
+	"indigo":               color.RGBA{75, 0, 130, 255},
+	"ivory":                color.RGBA{255, 255, 240, 255},
+	"khaki":                color.RGBA{240, 230, 140, 255},
+	"lavender":             color.RGBA{230, 230, 250, 255},
+	"lavenderblush":        color.RGBA{255, 240, 245, 255},
+	"lawngreen":            color.RGBA{124, 252, 0, 255},
+	"lemonchiffon":         color.RGBA{255, 250, 205, 255},
+	"lightblue":            color.RGBA{173, 216, 230, 255},
+	"lightcoral":           color.RGBA{240, 128, 128, 255},
+	"lightcyan":            color.RGBA{224, 255, 255, 255},
+	"lightgoldenrodyellow": color.RGBA{250, 250, 210, 255},
+	"lightgray":            color.RGBA{211, 211, 211, 255},
+	"lightgreen":           color.RGBA{144, 238, 144, 255},
+	"lightgrey":            color.RGBA{211, 211, 211, 255},
+	"lightpink":            color.RGBA{255, 182, 193, 255},
+	"lightsalmon":          color.RGBA{255, 160, 122, 255},
+	"lightseagreen":        color.RGBA{32, 178, 170, 255},
+	"lightskyblue":         color.RGBA{135, 206, 250, 255},
+	"lightslategray":       color.RGBA{119, 136, 153, 255},
+	"lightslategrey":       color.RGBA{119, 136, 153, 255},
+	"lightsteelblue":       color.RGBA{176, 196, 222, 255},
+	"lightyellow":          color.RGBA{255, 255, 224, 255},
+	"lime":                 color.RGBA{0, 255, 0, 255},
+	"limegreen":            color.RGBA{50, 205, 50, 255},
+	"linen":                color.RGBA{250, 240, 230, 255},
+	"magenta":              color.RGBA{255, 0, 255, 255},
+	"maroon":               color.RGBA{128, 0, 0, 255},
+	"mediumaquamarine":     color.RGBA{102, 205, 170, 255},
+	"mediumblue":           color.RGBA{0, 0, 205, 255},
+	"mediumorchid":         color.RGBA{186, 85, 211, 255},
+	"mediumpurple":         color.RGBA{147, 112, 219, 255},
+	"mediumseagreen":       color.RGBA{60, 179, 113, 255},
+	"mediumslateblue":      color.RGBA{123, 104, 238, 255},
+	"mediumspringgreen":    color.RGBA{0, 250, 154, 255},
+	"mediumturquoise":      color.RGBA{72, 209, 204, 255},
+	"mediumvioletred":      color.RGBA{199, 21, 133, 255},
+	"midnightblue":         color.RGBA{25, 25, 112, 255},
+	"mintcream":            color.RGBA{245, 255, 250, 255},
+	"mistyrose":            color.RGBA{255, 228, 225, 255},
+	"moccasin":             color.RGBA{255, 228, 181, 255},
+	"navajowhite":          color.RGBA{255, 222, 173, 255},
+	"navy":                 color.RGBA{0, 0, 128, 255},
+	"oldlace":              color.RGBA{253, 245, 230, 255},
+	"olive":                color.RGBA{128, 128, 0, 255},
+	"olivedrab":            color.RGBA{107, 142, 35, 255},
+	"orange":               color.RGBA{255, 165, 0, 255},
+	"orangered":            color.RGBA{255, 69, 0, 255},
+	"orchid":               color.RGBA{218, 112, 214, 255},
+	"palegoldenrod":        color.RGBA{238, 232, 170, 255},
+	"palegreen":            color.RGBA{152, 251, 152, 255},
+	"paleturquoise":        color.RGBA{175, 238, 238, 255},
+	"palevioletred":        color.RGBA{219, 112, 147, 255},
+	"papayawhip":           color.RGBA{255, 239, 213, 255},
+	"peachpuff":            color.RGBA{255, 218, 185, 255},
+	"peru":                 color.RGBA{205, 133, 63, 255},
+	"pink":                 color.RGBA{255, 192, 203, 255},
+	"plum":                 color.RGBA{221, 160, 221, 255},
+	"powderblue":           color.RGBA{176, 224, 230, 255},
+	"purple":               color.RGBA{128, 0, 128, 255},
+	"rebeccapurple":        color.RGBA{102, 51, 153, 255},
+	"red":                  color.RGBA{255, 0, 0, 255},
+	"rosybrown":            color.RGBA{188, 143, 143, 255},
+	"royalblue":            color.RGBA{65, 105, 225, 255},
+	"saddlebrown":          color.RGBA{139, 69, 19, 255},
+	"salmon":               color.RGBA{250, 128, 114, 255},
+	"sandybrown":           color.RGBA{244, 164, 96, 255},
+	"seagreen":             color.RGBA{46, 139, 87, 255},
+	"seashell":             color.RGBA{255, 245, 238, 255},
+	"sienna":               color.RGBA{160, 82, 45, 255},
+	"silver":               color.RGBA{192, 192, 192, 255},
+	"skyblue":              color.RGBA{135, 206, 235, 255},
+	"slateblue":            color.RGBA{106, 90, 205, 255},
+	"slategray":            color.RGBA{112, 128, 144, 255},
+	"slategrey":            color.RGBA{112, 128, 144, 255},
+	"snow":                 color.RGBA{255, 250, 250, 255},
+	"springgreen":          color.RGBA{0, 255, 127, 255},
+	"steelblue":            color.RGBA{70, 130, 180, 255},
+	"tan":                  color.RGBA{210, 180, 140, 255},
+	"teal":                 color.RGBA{0, 128, 128, 255},
+	"thistle":              color.RGBA{216, 191, 216, 255},
+	"tomato":               color.RGBA{255, 99, 71, 255},
+	"turquoise":            color.RGBA{64, 224, 208, 255},
+	"violet":               color.RGBA{238, 130, 238, 255},
+	"wheat":                color.RGBA{245, 222, 179, 255},
+	"white":                color.RGBA{255, 255, 255, 255},
+	"whitesmoke":           color.RGBA{245, 245, 245, 255},
+	"yellow":               color.RGBA{255, 255, 0, 255},
+	"yellowgreen":          color.RGBA{154, 205, 50, 255},
 }
 
-func nearestColor(c color.Color) (nc color.Color, name string) {
+func nearestColor(c color.Color, colormap map[string]color.Color) (nc color.Color, name string) {
 	var mind uint32 = math.MaxUint32
-	for n, cc := range cssColModLvl4Colors {
+	for n, cc := range colormap {
 		d := colorDissimilarity(c, cc)
 		if d < mind || d == mind && strings.Compare(n, name) < 0 {
 			mind = d
@@ -239,9 +233,15 @@ func diff(a, b uint32) uint32 {
 	return a - b
 }
 
+// Hex is a Model for hex quadruplet color codes in the format #FF69B4FF,
+// including alpha.
+//
+// https://css-tricks.com/8-digit-hex-codes/
+var Hex Model = hex{}
+
 type hex struct{}
 
-func (mod hex) Name() string {
+func (mod hex) ID() string {
 	return "hex"
 }
 
@@ -268,6 +268,6 @@ func (mod hex) NameToColor(name string) (c color.Color, ok bool) {
 }
 
 func init() {
-	RegisterColorModel(CSSColModLvl4)
+	RegisterColorModel(Standard)
 	RegisterColorModel(Hex)
 }

--- a/writer.go
+++ b/writer.go
@@ -9,7 +9,7 @@ import (
 // Encode encodes the Image m to the Writer w in BI format using the Model mod.
 // This is usually a very lossy process.
 func Encode(w io.Writer, m image.Image, mod Model) error {
-	hdr := MagicNumber + "," + mod.Name() + "\n"
+	hdr := MagicNumber + "," + mod.ID() + "\n"
 	if _, err := w.Write([]byte(hdr)); err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR is a cleanup of the interface and names for color models. It renames `CssColModLvl4` to `Standard` which has the ID `v1`. Much better. It also cleans up the interfaces for color models and the implementation of those interfaces.